### PR TITLE
PMS5003 sensor testing firmware

### DIFF
--- a/src/PMS5003tester/.gitignore
+++ b/src/PMS5003tester/.gitignore
@@ -1,0 +1,5 @@
+.pio
+.vscode/.browse.c_cpp.db*
+.vscode/c_cpp_properties.json
+.vscode/launch.json
+.vscode/ipch

--- a/src/PMS5003tester/.vscode/extensions.json
+++ b/src/PMS5003tester/.vscode/extensions.json
@@ -1,0 +1,10 @@
+{
+    // See http://go.microsoft.com/fwlink/?LinkId=827846
+    // for the documentation about the extensions.json format
+    "recommendations": [
+        "platformio.platformio-ide"
+    ],
+    "unwantedRecommendations": [
+        "ms-vscode.cpptools-extension-pack"
+    ]
+}

--- a/src/PMS5003tester/include/README
+++ b/src/PMS5003tester/include/README
@@ -1,0 +1,39 @@
+
+This directory is intended for project header files.
+
+A header file is a file containing C declarations and macro definitions
+to be shared between several project source files. You request the use of a
+header file in your project source file (C, C++, etc) located in `src` folder
+by including it, with the C preprocessing directive `#include'.
+
+```src/main.c
+
+#include "header.h"
+
+int main (void)
+{
+ ...
+}
+```
+
+Including a header file produces the same results as copying the header file
+into each source file that needs it. Such copying would be time-consuming
+and error-prone. With a header file, the related declarations appear
+in only one place. If they need to be changed, they can be changed in one
+place, and programs that include the header file will automatically use the
+new version when next recompiled. The header file eliminates the labor of
+finding and changing all the copies as well as the risk that a failure to
+find one copy will result in inconsistencies within a program.
+
+In C, the usual convention is to give header files names that end with `.h'.
+It is most portable to use only letters, digits, dashes, and underscores in
+header file names, and at most one dot.
+
+Read more about using header files in official GCC documentation:
+
+* Include Syntax
+* Include Operation
+* Once-Only Headers
+* Computed Includes
+
+https://gcc.gnu.org/onlinedocs/cpp/Header-Files.html

--- a/src/PMS5003tester/lib/README
+++ b/src/PMS5003tester/lib/README
@@ -1,0 +1,46 @@
+
+This directory is intended for project specific (private) libraries.
+PlatformIO will compile them to static libraries and link into executable file.
+
+The source code of each library should be placed in a an own separate directory
+("lib/your_library_name/[here are source files]").
+
+For example, see a structure of the following two libraries `Foo` and `Bar`:
+
+|--lib
+|  |
+|  |--Bar
+|  |  |--docs
+|  |  |--examples
+|  |  |--src
+|  |     |- Bar.c
+|  |     |- Bar.h
+|  |  |- library.json (optional, custom build options, etc) https://docs.platformio.org/page/librarymanager/config.html
+|  |
+|  |--Foo
+|  |  |- Foo.c
+|  |  |- Foo.h
+|  |
+|  |- README --> THIS FILE
+|
+|- platformio.ini
+|--src
+   |- main.c
+
+and a contents of `src/main.c`:
+```
+#include <Foo.h>
+#include <Bar.h>
+
+int main (void)
+{
+  ...
+}
+
+```
+
+PlatformIO Library Dependency Finder will find automatically dependent
+libraries scanning project source files.
+
+More information about PlatformIO Library Dependency Finder
+- https://docs.platformio.org/page/librarymanager/ldf.html

--- a/src/PMS5003tester/platformio.ini
+++ b/src/PMS5003tester/platformio.ini
@@ -1,0 +1,16 @@
+; PlatformIO Project Configuration File
+;
+;   Build options: build flags, source filter
+;   Upload options: custom upload port, speed and extra flags
+;   Library options: dependencies, extra library storages
+;   Advanced options: extra scripting
+;
+; Please visit documentation for the other options and examples
+; https://docs.platformio.org/page/projectconf.html
+
+[env:megaatmega2560]
+platform = atmelavr
+board = megaatmega2560
+framework = arduino
+monitor_speed = 115200
+lib_extra_dirs = ~/Documents/Arduino/libraries

--- a/src/PMS5003tester/src/main.cpp
+++ b/src/PMS5003tester/src/main.cpp
@@ -1,9 +1,82 @@
-#include <Arduino.h>
+/*
+  this code tests the PMS5003 sensors on the airqo Gen5 devices.
+  the code is setup to run on any revison of the airqo monitors which may have varrying hardware designs 
 
+*/
+#include <Arduino.h>
+#include <PMS.h>
+#include <ArduinoJson.h>
+#define SENSORSWITCH 56 //sensors are switched by a P-channel mosfet controlled by IO56 on the atmega2560 MCU.
+PMS::DATA data;
+float sensor1Pm1,sensor1Pm25,sensor1Pm10;
+float sensor2Pm1,sensor2Pm25,sensor2Pm10;
+void SamplePmSensor(PMS sensor1,PMS sensor2,uint8_t sampleCount,bool pm1_too);// sample (pmsensor1,pm sensor1, sample count,1=include pm1 readings,0=excludepm1 readings)
 void setup() {
   // put your setup code here, to run once:
+  Serial.begin(115200);
 }
 
 void loop() {
   // put your main code here, to run repeatedly:
 }
+void SamplePmSensor(PMS sensor1,PMS sensor2,uint8_t sampleCount,bool pm1_too)
+{
+  digitalWrite(SENSORSWITCH,LOW); // logic 0 turns the mosfet  on >> turnig the sensors on
+  sensor1.wakeUp();
+  sensor2.wakeUp();
+  sensor1.requestRead();
+  sensor2.requestRead();
+  uint8_t failCount=0; //variable to count the number of times data was unsecefully read from the sensor
+    for(uint8_t sample=0;sample<sampleCount;sample++)
+    {        
+        Serial.print(F("        pm sample:"));Serial.println(sample);
+        if(sensor1.readUntil(data))
+        {
+            sensor1Pm25+=float(data.PM_AE_UG_2_5);
+            sensor1Pm10+=float(data.PM_AE_UG_10_0);
+            if(pm1_too){sensor1Pm1+=float(data.PM_AE_UG_1_0);Serial.print(F("sensor1 PM1.0 (ug/m3):"));Serial.println(sensor1Pm1/sample);}
+            Serial.print(F("sensor1 PM2.5 (ug/m3):"));
+            Serial.println(sensor1Pm25/sample);
+            Serial.print(F("sensor1 PM10.0 (ug/m3):"));
+            Serial.println(sensor1Pm10/sample);
+            Serial.println(F(" "));
+        }
+        else{
+            sample=sample-1;
+            Serial.println(F("failed to read sensor"));
+            failCount++;
+            if(failCount>=5)
+            {
+                sample=sampleCount;
+            }
+        }
+        if(sensor2.readUntil(data))
+        {
+            sensor2Pm25+=float(data.PM_AE_UG_2_5);
+            sensor2Pm10+=float(data.PM_AE_UG_10_0);
+            if(pm1_too){sensor2Pm1+=float(data.PM_AE_UG_1_0);Serial.print(F("sensor2 PM1.0 (ug/m3):"));Serial.println(sensor2Pm1/sample);}
+            Serial.print(F("sensor2 PM2.5 (ug/m3):"));
+            Serial.println(sensor2Pm25/sample);
+            Serial.print(F("sensor2 PM10.0 (ug/m3):"));
+            Serial.println(sensor2Pm10/sample);
+            Serial.println(F(" "));
+        }
+        else{
+            sample=sample-1;
+            Serial.println(F("failed to read sensor"));
+            failCount++;
+            if(failCount>=5)
+            {
+                sample=sampleCount;
+            }
+        }
+    }
+    StaticJsonDocument<200> PmSensorData;
+    PmSensorData["time"]="YR/DD/MM/HR/MIN/SEC -ZONE";
+    PmSensorData["s1_pm2_5"]=sensor1Pm25/sampleCount;
+    PmSensorData["s1_pm10"]=sensor1Pm10/sampleCount;
+    PmSensorData["s2_pm2_5"]=sensor2Pm25/sampleCount;
+    PmSensorData["s2_pm10"]=sensor2Pm10/sampleCount;
+    serializeJsonPretty(PmSensorData,Serial);
+}
+

--- a/src/PMS5003tester/test/README
+++ b/src/PMS5003tester/test/README
@@ -1,0 +1,11 @@
+
+This directory is intended for PlatformIO Test Runner and project tests.
+
+Unit Testing is a software testing method by which individual units of
+source code, sets of one or more MCU program modules together with associated
+control data, usage procedures, and operating procedures, are tested to
+determine whether they are fit for use. Unit testing finds problems early
+in the development cycle.
+
+More information about PlatformIO Unit Testing:
+- https://docs.platformio.org/en/latest/advanced/unit-testing/index.html


### PR DESCRIPTION
a simple firmware to test the PMS5003 particulate matter sensors used on the GEN5 airqo monitors, a first step towards adapting GitHub usage in hardware team.