### PR TITLE
Docs/fix nojekyll

### DIFF
--- a/docs/.vitepress/config.js
+++ b/docs/.vitepress/config.js
@@ -3,7 +3,7 @@ import { defineConfig } from 'vitepress'
 export default defineConfig({
   title: 'AirQo Hardware',
   description: 'Documentation for the AirQo Binos Air Quality Monitor and BAM Data Logger',
-  base: '/AirQo-hardware/',
+  base: '/AirQo-Hardware-RnD/',
 
   head: [
     ['link', { rel: 'icon', href: '/favicon.ico' }],


### PR DESCRIPTION


● Title: fix: add .nojekyll to prevent Jekyll from interfering with VitePress build

  Description:

   Without a .nojekyll file in the build output, GitHub Pages defaults to running Jekyll post-processing, which can strip or mishandle files in the VitePress output (particularly those starting with _). This causes the deployed site to render as a blank/default GitHub Pages page instead of the VitePress documentation.
   
   Fix: Added .nojekyll to docs/public/ so it is copied into the VitePress dist output at build time, disabling Jekyll processing and allowing the VitePress site to serve correctly.
   
   Tested: Confirmed working on  https://deogratius2phantom.github.io/AirQo-Hardware-RnD/ before raising this PR.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the documentation site's base path configuration to reflect the new hosting structure. The documentation is now served from a different URL prefix. Users who have bookmarked specific documentation pages or use direct links will need to update them to access the documentation at its new location.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->